### PR TITLE
Add Theme Versioning to source CSS

### DIFF
--- a/Material-Discord/css/source.css
+++ b/Material-Discord/css/source.css
@@ -1,4 +1,5 @@
 :root {
+	--material-discord-version:"2.2.3";
 	--accent-color: #3f51b5;
 	/*--accent-color-hover: #4558c4;
 	--accent-color-active: #5262bc;*/
@@ -15605,8 +15606,227 @@ body:active .layer-v9HyYc[style*="left: 80px"] .animatorTop-2Y7x2r .menu-Sp6bN1:
 	padding: 0;
 }
 
-.bd-addon-list .bd-addon-card.settings-open div[style="float: right; cursor: pointer;"]:not([class]) {
-	float: none !important;
+.repo-controls .searchBarIcon-18QaPq,
+.DevilBro-modal .tabBarContainer-1s1u-z .searchBarIcon-18QaPq {
+	width: 32px;
+	height: 32px;
+	margin: 0;
+}
+
+.repo-controls .searchBarIcon-18QaPq .icon-1S6UIr,
+.DevilBro-modal .tabBarContainer-1s1u-z .searchBarIcon-18QaPq .icon-1S6UIr {
+	width: 18px;
+	height: 18px;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	margin: auto;
+}
+
+.DevilBro-modal .header-2nhbou {
+	height: 40px;
+	padding: 10px 12px 0 12px !important;
+	border-radius: var(--border-radius-big) var(--border-radius-big) 0 0;
+}
+
+.DevilBro-modal .tabBarContainer-1s1u-z {
+	margin: 0;
+	padding: 0 12px;
+	box-shadow: var(--shadow-1dp) !important;
+	z-index: 2;
+}
+
+.DevilBro-modal .tabBar-2MuP6- {
+	height: 48px;
+}
+
+.DevilBro-modal .tabBarItem-1b8RUP {
+	margin: 0 20px 0 0;
+}
+
+.DevilBro-modal .tabBarItem-1b8RUP:last-child {
+	margin: 0;
+}
+
+.DevilBro-modal .header-2nhbou,
+.DevilBro-modal .tabBarContainer-1s1u-z {
+	background: var(--popout-color) !important;
+}
+
+.DevilBro-modal .header-2nhbou .close-18n9bP {
+	width: 18px;
+	height: 18px;
+	padding: 8px;
+}
+
+.pluginrepo-modal .pluginEntry .favIcon,
+.themerepo-modal .themeEntry .favIcon {
+	width: 24px !important;
+	height: 24px !important;
+}
+
+.pluginrepo-modal .pluginEntry .favIcon path,
+.themerepo-modal .themeEntry .favIcon path {
+	d: path('M22 9.24l-7.19-.62L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.63-7.03L22 9.24zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z') !important;
+}
+
+.pluginrepo-modal .pluginEntry .favIcon:not(.favorized) path,
+.themerepo-modal .themeEntry .favIcon:not(.favorized) path {
+	fill: #888 !important;
+	stroke: #888 !important;
+}
+
+.modal-3v8ziU .header-2nhbou.marginBottom20-32qID7 {
+	margin: 0 !important;
+}
+
+.pluginrepo-modal .tab-content .inner-3wn6Q5,
+.pluginrepo-modal .tab-content.inner-3wn6Q5,
+.themerepo-modal .tab-content .inner-3wn6Q5,
+.themerepo-modal .tab-content.inner-3wn6Q5 {
+	padding: 16px 12px 0 20px;
+}
+
+.ui-standard-sidebar-view #bd-settingspane-container {
+	background: var(--main-color) !important;
+}
+
+#bd-settingspane-container .ui-switch-item {
+	padding: 8px 0;
+	border-bottom: 1px solid var(--card-border-color);
+}
+
+#bd-settingspane-container .ui-switch-item .ui-switch-wrapper {
+	top: 16px !important;
+}
+
+#bd-settingspane-container .bda-slist .ui-switch-item {
+	padding: 0 !important;
+	margin: 0 0 16px 0 !important;
+}
+
+#bd-settingspane-container .bda-slist .ui-switch-item.settings-open {
+	position: relative !important;
+}
+
+#bd-settingspane-container .bda-slist .ui-switch-item.settings-open div[style*="float: right"] svg {
+	position: absolute !important;
+	top: 16px !important;
+	right: 16px !important;
+}
+
+#bd-settingspane-container .bda-slist .ui-switch-item .ui-switch-wrapper {
+	top: 0 !important;
+}
+
+#bd-settingspane-container .bda-slist li[data-name="Material_Discord"] .bda-header-title .bda-version {
+  font-size: 0; }
+  
+#bd-settingspane-container .bda-slist li[data-name="Material_Discord"] .bda-header-title .bda-version::after {
+  content: var(--material-discord-version);
+  font-size: 12px; }
+
+#bd-settingspane-container .bda-header {
+	padding: 16px !important;
+}
+
+#bd-settingspane-container .bda-header .bda-name {
+	font-size: 1.25em !important;
+}
+
+#bd-settingspane-container .bda-description-wrap {
+	padding: 8px 16px !important;
+}
+
+#bd-settingspane-container .bda-footer {
+	min-height: 54px !important;
+	padding: 8px !important;
+}
+
+#bd-settingspane-container .bda-footer .bda-links {
+	margin: 0 0 0 8px !important;
+}
+
+#bd-settingspane-container .bda-footer .bda-links a {
+	color: var(--accent-color) !important;
+}
+
+#bd-settingspane-container .ui-switch-item h3 {
+	color: #b9bbbe;
+}
+
+#bd-settingspane-container .ui-switch-item .style-description {
+	line-height: 16px;
+	color: #888;
+	border: none;
+}
+
+#bd-settingspane-container .ui-switch-item:last-child {
+	border-bottom: none;
+}
+
+#bd-settingspane-container input[type="checkbox"]:after {
+	background-color: rgba(65,65,65,0.65);
+}
+
+#bd-settingspane-container .bda-description {
+	min-height: 24px !important;
+	max-height: 150px !important;
+	margin: 0;
+	font-size: 16px !important;
+	color: #888 !important;
+	overflow-y: scroll;
+}
+
+#bd-settingspane-container .bda-header .trashIcon {
+	top: 24px !important;
+	right: 72px;
+}
+
+#bd-settingspane-container .bda-right .trashIcon,
+#bd-settingspane-container .bda-header .trashIcon {
+	right: 60px !important;
+}
+
+#bd-settingspane-container .bda-header .trashIcon path:last-child,
+.bda-footer .trashIcon path {
+	d: path('M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM8 9h8v10H8V9zm7.5-5l-1-1h-5l-1 1H5v2h14V4h-3.5z') !important;
+	fill: #ccc;
+	transform: translate(-2px, -2px);
+}
+
+#bd-settingspane-container .bda-header .trashIcon path:first-child {
+	display: none;
+}
+
+#bd-settingspane-container .bda-header .trashIcon path {
+
+}
+
+#bd-settingspane-container .editIcon path,
+#bd-settingspane-container .editIcon polygon {
+	display: none;
+}
+
+#bd-settingspane-container .editIcon path:last-child {
+	display: block;
+	d: path('M14.06 9.02l.92.92L5.92 19H5v-.92l9.06-9.06M17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75z') !important;
+	fill: #ccc;
+	transform: scale(24) translate(-2px, -2px);
+}
+
+#bd-settingspane-container .bda-left {
+	width: calc(100% - 115px) !important;
+}
+
+#bd-settingspane-container .bda-right {
+	position: relative !important;
+	width: 100px !important;
+	height: 62px !important;
+}
+
+#bd-settingspane-container .bda-right button {
 	position: absolute;
 	top: 16px;
 	right: 16px;

--- a/Material-Discord/css/source.css
+++ b/Material-Discord/css/source.css
@@ -1,5 +1,5 @@
 :root {
-	--material-discord-version:"2.2.3";
+	--material-discord-version:"2.2.5";
 	--accent-color: #3f51b5;
 	/*--accent-color-hover: #4558c4;
 	--accent-color-active: #5262bc;*/

--- a/Material-Discord/css/source.css
+++ b/Material-Discord/css/source.css
@@ -1,5 +1,5 @@
 :root {
-	--material-discord-version:"2.2.5";
+	--material-discord-version:"2.2.6";
 	--accent-color: #3f51b5;
 	/*--accent-color-hover: #4558c4;
 	--accent-color-active: #5262bc;*/


### PR DESCRIPTION
Material Discord is a self-updating theme (source and theme CSS separated). This causes BetterDiscord to still display the old version number in the theme settings, even after source CSS is updated.

This fix enables users on Material Discord theme to see the actual versioning of the source theme, without manually updating the theme CSS file.