### PR TITLE
source.css without watermark

### DIFF
--- a/Themes/Material-Discord/css/source.css
+++ b/Themes/Material-Discord/css/source.css
@@ -982,10 +982,6 @@ div[role="radiogroup"] {
   width: auto;
   height: 22px; }
 
-.wordmark-2iDDfm:before {
-  content: "Material";
-  font-weight: 700; }
-
 .wordmark-2iDDfm:after {
   content: "Discord"; }
 


### PR DESCRIPTION
Hi i am not sure if this will work but i try to edit source to remove watermark cause so many people think Material next to discord isn't nice so if you can remove this material next to Discord please remove it.

Thanks