### PR TITLE
Make the Icon bar functional on mac

### DIFF
--- a/Translucence/css/source.css
+++ b/Translucence/css/source.css
@@ -110,6 +110,10 @@
   height: 100%;
   color: #fff; }
 
+.platform-osx .wrapper-3NnKdC{
+	padding-top: 35px;
+}
+
 /* APP ELEMENTS -> NOTIFICATION BAR */
 .notice-2FJMB4,
 .noticeWrapper-8z511t,


### PR DESCRIPTION
This will resolve a bug where the home button is under the close buttons in MacOS.

[See the results](https://imgur.com/a/JRVdJ90)