### PR TITLE
Remove usrbg database import

### DIFF
--- a/Themes/Material-Discord/css/source.css
+++ b/Themes/Material-Discord/css/source.css
@@ -1,4 +1,3 @@
-@import url("https://discord-custom-covers.github.io/usrbg/dist/usrbg.css");
 :root {
   --app-bg: var(--main-alt);
   --accent-color: #577be2;


### PR DESCRIPTION
You seem to be importing the usrbg database which does nothing but cause the theme to lag, all you need is whats in lines 6921-6963 to make it work. BDFDB already takes care of the usrbg database now.
![](https://cdn.discordapp.com/attachments/863475860980236318/867449922235269120/unknown.png)
above is an image of me removing the import
![](https://cdn.discordapp.com/attachments/863475860980236318/867451601362223184/unknown.png)
above is an image with all my themes off
![](https://cdn.discordapp.com/attachments/863475860980236318/867447878008176680/unknown.png)
and above is an image of me having a usrbg without the import