### PR TITLE
Add Variables for Media and Audio Radius

### DIFF
--- a/Themes/Material-Discord/css/source.css
+++ b/Themes/Material-Discord/css/source.css
@@ -18,6 +18,7 @@
   --message-radius: 19px;
   --message-padding: 8px 12px;
   --message-padding-alt: 4px 12px 8px 12px;
+  --media-radius: 19px;
   --main-textarea-radius: 24px;
   --card-radius: 8px;
   --card-radius-big: 16px;
@@ -2779,14 +2780,14 @@ html:not(.app-focused) .typeWindows-1za-n7 .winButton-iRh8-Z.winButtonMinMax-PBQ
       border-top-color: var(--popout-color); }
 
 /* CHAT AREA -> MESSAGES -> ATTACHMENTS -> IMAGES */
-.imageWrapper-2p5ogY.embedWrapper-lXpS3L {
-  border-radius: var(--message-radius); }
+.imageWrapper-2p5ogY.embedWrapper-lXpS3L, .imageWrapper-2p5ogY.embedWrapper-lXpS3L video, .imageWrapper-2p5ogY .wrapper-2TxpI8 {
+  border-radius: var(--media-radius); }
 
-.embedMedia-1guQoW {
-  border-radius: var(--message-radius); }
+.embedMedia-1guQoW, .embedMedia-1guQoW img, .embedMedia-1guQoW video, .embedMedia-1guQoW .imageWrapper-2p5ogY {
+  border-radius: var(--media-radius); }
 
 .spoilerContainer-331r0R {
-  border-radius: var(--message-radius);
+  border-radius: var(--media-radius);
   box-shadow: none !important; }
 
 /* CHAT AREA -> MAIN TEXTAREA */

--- a/Themes/Material-Discord/css/source.css
+++ b/Themes/Material-Discord/css/source.css
@@ -19,6 +19,7 @@
   --message-padding: 8px 12px;
   --message-padding-alt: 4px 12px 8px 12px;
   --media-radius: 19px;
+  --audio-radius: 12px;
   --main-textarea-radius: 24px;
   --card-radius: 8px;
   --card-radius-big: 16px;
@@ -2708,7 +2709,7 @@ html:not(.app-focused) .typeWindows-1za-n7 .winButton-iRh8-Z.winButtonMinMax-PBQ
 .wrapperAudio-1jDe0Q {
   padding: 0;
   background-color: var(--attachment-color) !important;
-  border-radius: var(--message-radius);
+  border-radius: var(--audio-radius);
   border: none; }
   .wrapperAudio-1jDe0Q .audioMetadata-3zOuGv {
     padding: 8px; }


### PR DESCRIPTION
I wasn't fond of how  strong the radius is on both the Media and Audio previews, so I made variables to be able to be able to change them individually if people want to.
All the extra selectors are necessary from my testing to get past discord's 4-3px default radius.
I also changed the Audio preview radius' default to 12px because it fits better with the rest of the icon's sizing now that its independently editable.