### PR TITLE
recent fixes put together

### DIFF
--- a/Themes/Translucence/css/source.css
+++ b/Themes/Translucence/css/source.css
@@ -2184,14 +2184,13 @@ body {
   border-radius: 0 0 var(--card-radius) var(--card-radius);
 }
 
-.textContainer-36wgKK {
+.newMosaicStyle-2jdUaP .textContainer-36wgKK {
   border-radius: var(--card-radius) var(--card-radius) 0 0;
   box-shadow: var(--card-header-shadow);
 }
-.textContainer-36wgKK .hljs {
+.newMosaicStyle-2jdUaP .textContainer-36wgKK .hljs {
   background-color: transparent;
 }
-
 .newMosaicStyle-2jdUaP .footer-GXWBBp {
   border-radius: 0 0 var(--card-radius) var(--card-radius);
 }
@@ -4412,7 +4411,7 @@ body {
   border-radius: var(--card-radius) 0 0 var(--card-radius);
 }
 .selected-3jieYB.passthrough--fbdFR {
-  background-color: hsla(217deg, 8%, 41%, 0.65);
+  background-color: hsla(217, 8%, 41%, 0.65);
 }
 .selected-3jieYB.allow-1h61-Z {
   background-color: hsl(139, calc(var(--saturation-factor, 1) * 47.3%), 43.9%, 0.65);
@@ -4462,7 +4461,10 @@ body {
   background-color: var(--background-modifier-active);
 }
 .roleRow-230vCm:hover .button-1_oXub {
-  background-color: var(--main-content-color) !important;
+  background-color: var(--background-modifier-active) !important;
+}
+.roleRow-230vCm:hover .button-1_oXub:hover {
+  background-color: var(--background-modifier-hover) !important;
 }
 
 /* SERVER SETTINGS ROLES -> EDIT ROLE */
@@ -4712,7 +4714,7 @@ body {
   background-color: transparent !important;
 }
 .payment-2bOh4k.bottomDivider-ZmTm-j {
-  border-bottom-color: hsla(0deg, 0%, 100%, 0.1);
+  border-bottom-color: hsla(0, 0%, 100%, 0.1);
 }
 
 .expandedInfo-1W31i3 {
@@ -5017,4 +5019,13 @@ body {
 .backgroundOption-2mIYjm .backgroundOptionInner-SSz19O {
   background: var(--card-color);
   border-radius: var(--card-radius);
+}
+
+/*
+ *
+ *  USERPROFILES
+ *
+ */
+.wrapper-3Un6-K .pointerEvents-2KjWnj {
+  filter: saturate(var(--saturation-factor));
 }

--- a/Themes/Translucence/css/source.css
+++ b/Themes/Translucence/css/source.css
@@ -228,7 +228,7 @@ body {
   border-radius: var(--list-item-radius);
 }
 .sidebar-1tnWFu .voiceChannelsButton-SRmgo8:hover {
-  background-color: var(--background-modifier-selected);
+  background-color: var(--background-modifier-hover);
 }
 
 .header-3OsQeK {
@@ -2153,21 +2153,16 @@ body {
 }
 
 /* ATTACHMENTS -> TEXT CONTAINER */
-.textContainer-36wgKK,
-.footer-GXWBBp {
+.newMosaicStyle-2jdUaP .textContainer-36wgKK,
+.newMosaicStyle-2jdUaP .footer-GXWBBp {
   background-color: var(--card-color);
   border: none;
 }
-
-.textContainer-36wgKK {
+.newMosaicStyle-2jdUaP .textContainer-36wgKK {
   border-radius: var(--card-radius) var(--card-radius) 0 0;
   box-shadow: var(--card-header-shadow);
 }
-.textContainer-36wgKK .hljs {
-  background-color: transparent;
-}
-
-.footer-GXWBBp {
+.newMosaicStyle-2jdUaP .footer-GXWBBp {
   border-radius: 0 0 var(--card-radius) var(--card-radius);
 }
 
@@ -2176,6 +2171,9 @@ body {
   border-radius: var(--popout-radius) var(--popout-radius) 0 0;
   border: none;
   box-shadow: var(--card-header-shadow);
+}
+.modalTextContainer-1FUO2W .hljs {
+  background-color: transparent;
 }
 
 /*
@@ -2190,7 +2188,7 @@ body {
   border-radius: var(--card-radius);
 }
 .markup-eYLPri code {
-  background-color: var(--card-color);
+  background-color: var(--textarea-block-color);
   border-radius: var(--card-radius);
   border: none;
 }
@@ -4369,7 +4367,7 @@ body {
   border-radius: var(--card-radius) 0 0 var(--card-radius);
 }
 .selected-3jieYB.passthrough--fbdFR {
-  background-color: hsla(217, 8%, 41%, 0.65);
+  background-color: hsla(217deg, 8%, 41%, 0.65);
 }
 .selected-3jieYB.allow-1h61-Z {
   background-color: hsl(139, calc(var(--saturation-factor, 1) * 47.3%), 43.9%, 0.65);
@@ -4661,7 +4659,7 @@ body {
   background-color: transparent !important;
 }
 .payment-2bOh4k.bottomDivider-ZmTm-j {
-  border-bottom-color: hsla(0, 0%, 100%, 0.1);
+  border-bottom-color: hsla(0deg, 0%, 100%, 0.1);
 }
 
 .expandedInfo-1W31i3 {
@@ -4941,3 +4939,9 @@ body {
 .profileBannerPreview-3mLIdO .fakeActivityWrapper-2i1oU- {
   padding: 0 16px 0;
 }
+
+/*
+ *
+ *  USER SETTINGS SERVER BOOST
+ *
+ */

--- a/Themes/Translucence/css/source.css
+++ b/Themes/Translucence/css/source.css
@@ -1379,16 +1379,16 @@ body {
   border: none !important;
 }
 
-.contentColumn-1C7as6 .cardPrimary-pAe8Ed {
+.cardPrimary-pAe8Ed {
   border-style: solid !important;
   border-width: 1px !important;
   border-color: transparent !important;
 }
-.contentColumn-1C7as6 .cardPrimary-pAe8Ed .cardHeader-3d6H8N {
+.cardPrimary-pAe8Ed .cardHeader-3d6H8N {
   background-color: unset;
   border-bottom: 1px solid var(--card-color);
 }
-.contentColumn-1C7as6 .cardPrimary-pAe8Ed .group-1-kPpw {
+.cardPrimary-pAe8Ed .group-1-kPpw {
   background-color: var(--card-color);
   border-radius: var(--button-radius);
   border: none;

--- a/Themes/Translucence/css/source.css
+++ b/Themes/Translucence/css/source.css
@@ -3,8 +3,11 @@
   --app-blur: 6px;
   --app-margin: 24px;
   --app-radius: 10px;
-  --sidebar-color: rgba(0,0,0,0.4);
-  --main-content-color: rgba(0,0,0,0.2);
+  --main-rgb: 0,0,0;
+  --main-content-opacity: 0.2;
+  --sidebar-opacity: 0.4;
+  --main-content-color: rgba(var(--main-rgb), var(--main-content-opacity));
+  --sidebar-color: rgba(var(--main-rgb), var(--sidebar-opacity));
   --accent-hue: 156;
   --accent-saturation: 77.5%;
   --accent-lightness: 47.1%;
@@ -511,7 +514,7 @@ body {
  *
  */
 .searchResultsWrap-5RVOkx {
-  background-color: var(--sidebar-color);
+  background-color: rgba(var(--main-rgb), calc((var(--sidebar-opacity) - var(--main-content-opacity)) / (1 - var(--main-content-opacity))));
 }
 
 /* SEARCH RESULTS -> HEADER */
@@ -1376,6 +1379,22 @@ body {
   border: none !important;
 }
 
+.applicationPermissions-3bwpAg .cardPrimary-pAe8Ed {
+  border-style: solid !important;
+  border-width: 1px !important;
+  border-color: transparent !important;
+}
+.applicationPermissions-3bwpAg .cardPrimary-pAe8Ed .cardHeader-3d6H8N {
+  background-color: unset;
+  border-bottom: 1px solid var(--card-color);
+}
+.applicationPermissions-3bwpAg .cardPrimary-pAe8Ed .group-1-kPpw {
+  background-color: var(--card-color);
+  border-radius: var(--button-radius);
+  border: none;
+  overflow: hidden;
+}
+
 .button-1yVL_7 {
   background-color: var(--card-color) !important;
 }
@@ -2132,6 +2151,11 @@ body {
   background-color: var(--card-color) !important;
   border-radius: var(--card-radius);
   border: none;
+}
+
+.inviteSplash-2nkLRX {
+  border-top-right-radius: var(--card-radius);
+  border-top-left-radius: var(--card-radius);
 }
 
 .container-3M84ky {
@@ -3046,6 +3070,12 @@ body {
 .menu-2TXYjN .submenu-3ycVEH:before {
   width: calc(100% - 16px);
   left: 8px;
+}
+.menu-2TXYjN .button-1zW0-r {
+  background-color: var(--card-color);
+}
+.menu-2TXYjN .button-1zW0-r:hover {
+  background-color: var(--card-color-hover);
 }
 
 /*
@@ -4228,6 +4258,15 @@ body {
   border: none;
 }
 
+.developerPortalCtaWrapper-2PniQs {
+  background-color: var(--card-color);
+}
+
+.error-2568aZ {
+  background-color: var(--card-color);
+  border-radius: var(--card-radius);
+}
+
 /*
  *
  *  SERVER SETTINGS MEMBERSHIP SCREENING
@@ -4529,13 +4568,21 @@ body {
   background-color: var(--card-color-hover);
   border: none;
 }
-
 .background-3xJH_4 {
   color: var(--card-color) !important;
 }
 
-.tierInProgress-1vFUnw {
-  background-color: var(--card-color) !important;
+.foreground-3_3Pgi {
+  color: hsla(var(--accent-hsl), var(--accent-opacity));
+}
+
+.theme-dark .tierInProgress-1vFUnw {
+  background-color: var(--card-color);
+}
+.theme-dark .tierAccomplished-1I5NaT,
+.theme-dark .tierCurrent-2nowYi,
+.theme-dark .tierFirst-1Vn3wS {
+  background: hsla(var(--accent-hsl), var(--accent-opacity));
 }
 
 /*
@@ -4951,3 +4998,23 @@ body {
  *  USER SETTINGS SERVER BOOST
  *
  */
+/*
+ *
+ *  USER SETTINGS VOICE & VIDEO
+ *
+ */
+.cameraWrapper-nG8dpo {
+  background: var(--card-color);
+  border-radius: var(--card-radius);
+  border-color: hsla(var(--accent-hsl), var(--accent-opacity));
+  border-width: 2px;
+}
+
+.backgroundOption-2mIYjm .backgroundOptionRing-1vvQ0C {
+  border-radius: var(--card-radius);
+  border-color: hsla(var(--accent-hsl), var(--accent-opacity));
+}
+.backgroundOption-2mIYjm .backgroundOptionInner-SSz19O {
+  background: var(--card-color);
+  border-radius: var(--card-radius);
+}

--- a/Themes/Translucence/css/source.css
+++ b/Themes/Translucence/css/source.css
@@ -1379,16 +1379,16 @@ body {
   border: none !important;
 }
 
-.applicationPermissions-3bwpAg .cardPrimary-pAe8Ed {
+.contentColumn-1C7as6 .cardPrimary-pAe8Ed {
   border-style: solid !important;
   border-width: 1px !important;
   border-color: transparent !important;
 }
-.applicationPermissions-3bwpAg .cardPrimary-pAe8Ed .cardHeader-3d6H8N {
+.contentColumn-1C7as6 .cardPrimary-pAe8Ed .cardHeader-3d6H8N {
   background-color: unset;
   border-bottom: 1px solid var(--card-color);
 }
-.applicationPermissions-3bwpAg .cardPrimary-pAe8Ed .group-1-kPpw {
+.contentColumn-1C7as6 .cardPrimary-pAe8Ed .group-1-kPpw {
   background-color: var(--card-color);
   border-radius: var(--button-radius);
   border: none;

--- a/Themes/Translucence/css/source.css
+++ b/Themes/Translucence/css/source.css
@@ -2153,16 +2153,21 @@ body {
 }
 
 /* ATTACHMENTS -> TEXT CONTAINER */
-.newMosaicStyle-2jdUaP .textContainer-36wgKK,
-.newMosaicStyle-2jdUaP .footer-GXWBBp {
+.textContainer-36wgKK,
+.footer-GXWBBp {
   background-color: var(--card-color);
   border: none;
 }
-.newMosaicStyle-2jdUaP .textContainer-36wgKK {
+
+.textContainer-36wgKK {
   border-radius: var(--card-radius) var(--card-radius) 0 0;
   box-shadow: var(--card-header-shadow);
 }
-.newMosaicStyle-2jdUaP .footer-GXWBBp {
+.textContainer-36wgKK .hljs {
+  background-color: transparent;
+}
+
+.footer-GXWBBp {
   border-radius: 0 0 var(--card-radius) var(--card-radius);
 }
 

--- a/Themes/Translucence/css/source.css
+++ b/Themes/Translucence/css/source.css
@@ -2157,6 +2157,7 @@ body {
 .footer-GXWBBp {
   background-color: var(--card-color);
   border: none;
+  border-radius: 0 0 var(--card-radius) var(--card-radius);
 }
 
 .textContainer-36wgKK {
@@ -2167,7 +2168,7 @@ body {
   background-color: transparent;
 }
 
-.footer-GXWBBp {
+.newMosaicStyle-2jdUaP .footer-GXWBBp {
   border-radius: 0 0 var(--card-radius) var(--card-radius);
 }
 

--- a/Themes/Translucence/main.scss
+++ b/Themes/Translucence/main.scss
@@ -134,5 +134,6 @@
 @use 'src/settings/user/partyMode';
 @use 'src/settings/user/profile';
 @use 'src/settings/user/settingsServerBoost';
+@use 'src/settings/user/voiceVideo';
 
 @import 'src/selectorPlaceholders';

--- a/Themes/Translucence/main.scss
+++ b/Themes/Translucence/main.scss
@@ -136,4 +136,6 @@
 @use 'src/settings/user/settingsServerBoost';
 @use 'src/settings/user/voiceVideo';
 
+@use 'src/userprofiles/userprofiles';
+
 @import 'src/selectorPlaceholders';

--- a/Themes/Translucence/src/_selectorPlaceholders.scss
+++ b/Themes/Translucence/src/_selectorPlaceholders.scss
@@ -6754,9 +6754,6 @@ pre {
 .emptyText-29ycwI {
 	@extend %emptyActiveNowText !optional;
 }
-.button-1zW0-r {
-	@extend %quickReactButton !optional;
-}
 .focused-H4w81f {
 	@extend %quickReactButtonFocused !optional;
 }

--- a/Themes/Translucence/src/_selectorPlaceholders.scss
+++ b/Themes/Translucence/src/_selectorPlaceholders.scss
@@ -3376,6 +3376,9 @@
 .video-2HW4jD {
 	@extend %attachmentVideo !optional;
 }
+.newMosaicStyle-2jdUaP {
+	@extend %attachmentNewMosaicStyle !optional;
+}
 .icon-1KCy88 {
 	@extend %attachmentIcon !optional;
 }

--- a/Themes/Translucence/src/_selectorPlaceholders.scss
+++ b/Themes/Translucence/src/_selectorPlaceholders.scss
@@ -5473,6 +5473,12 @@ pre {
 .applicationPermissions-3bwpAg {
 	@extend %applicationPermissions !optional;
 }
+.cardHeader-3d6H8N {
+	@extend %applicationPermissionsCardHeader !optional;
+}
+.group-1-kPpw {
+	@extend %applicationPermissionButtonGroup !optional;
+}
 .card-16VQ8C {
 	@extend %settingsCard !optional;
 }

--- a/Themes/Translucence/src/_selectorPlaceholders.scss
+++ b/Themes/Translucence/src/_selectorPlaceholders.scss
@@ -5470,14 +5470,11 @@ pre {
 .imageUploaderIcon-2OHmFu {
 	@extend %settingsImageUploaderIcon !optional;
 }
-.applicationPermissions-3bwpAg {
-	@extend %applicationPermissions !optional;
-}
 .cardHeader-3d6H8N {
 	@extend %applicationPermissionsCardHeader !optional;
 }
 .group-1-kPpw {
-	@extend %applicationPermissionButtonGroup !optional;
+	@extend %applicationPermissionsButtonGroup !optional;
 }
 .card-16VQ8C {
 	@extend %settingsCard !optional;

--- a/Themes/Translucence/src/_selectorPlaceholders.scss
+++ b/Themes/Translucence/src/_selectorPlaceholders.scss
@@ -5470,6 +5470,9 @@ pre {
 .imageUploaderIcon-2OHmFu {
 	@extend %settingsImageUploaderIcon !optional;
 }
+.applicationPermissions-3bwpAg {
+	@extend %applicationPermissions !optional;
+}
 .card-16VQ8C {
 	@extend %settingsCard !optional;
 }

--- a/Themes/Translucence/src/_selectorPlaceholders.scss
+++ b/Themes/Translucence/src/_selectorPlaceholders.scss
@@ -3361,9 +3361,6 @@
 .attachment-1PZZB2 {
 	@extend %attachment !optional;
 }
-.newMosaicStyle-35X6XO {
-	@extend %attachmentNewMosiacStyle !optional;
-}
 .nonMediaAttachment-3C_4Pd {
 	@extend %attachmentNonMediaAttachment !optional;
 }
@@ -3379,8 +3376,8 @@
 .video-2HW4jD {
 	@extend %attachmentVideo !optional;
 }
-.embedWrapper-1MtIDg {
-	@extend %attachmentEmbedWrapper !optional;
+.newMosaicStyle-2jdUaP {
+	@extend %newMosaicStyle !optional;
 }
 .icon-1KCy88 {
 	@extend %attachmentIcon !optional;

--- a/Themes/Translucence/src/_selectorPlaceholders.scss
+++ b/Themes/Translucence/src/_selectorPlaceholders.scss
@@ -3376,9 +3376,6 @@
 .video-2HW4jD {
 	@extend %attachmentVideo !optional;
 }
-.newMosaicStyle-2jdUaP {
-	@extend %newMosaicStyle !optional;
-}
 .icon-1KCy88 {
 	@extend %attachmentIcon !optional;
 }

--- a/Themes/Translucence/src/_selectorPlaceholders.scss
+++ b/Themes/Translucence/src/_selectorPlaceholders.scss
@@ -1765,9 +1765,6 @@
 .tabButton-1hJ4oW {
 	@extend %autocompletetabButton !optional;
 }
-.wrapper-3Un6-K {
-	@extend %autocompleteAvatarWrapper !optional;
-}
 .mobileContainer-38hqQU {
 	@extend %mobileContainer !optional;
 }
@@ -6342,6 +6339,9 @@ pre {
 }
 .wrapper-3Un6-K {
 	@extend %avatarWrapper !optional;
+}
+.pointerEvents-2KjWnj {
+	@extend %avatarStatusRect !optional;
 }
 .mask-1FEkla {
 	@extend %avatarMask !optional;

--- a/Themes/Translucence/src/_selectorPlaceholders.scss
+++ b/Themes/Translucence/src/_selectorPlaceholders.scss
@@ -6820,6 +6820,9 @@ pre {
 .placeholderCard-3eGmb3 {
 	@extend %stickersPlaceholderCard !optional;
 }
+.action-2YPPom {
+	@extend %stickersCardButtons !optional;
+}
 .form-QIWuKf {
 	@extend %stickersUploadForm !optional;
 }
@@ -6834,6 +6837,15 @@ pre {
 }
 .foreground-3_3Pgi {
 	@extend %stickersProgressForground !optional;
+}
+.tierAccomplished-1I5NaT {
+	@extend %stickersTierAccomplished !optional;
+}
+.tierCurrent-2nowYi {
+	@extend %stickersTierCurrent !optional;
+}
+.tierFirst-1Vn3wS{
+	@extend %stickersTierFirst !optional;
 }
 .tierInProgress-1vFUnw {
 	@extend %stickersTierInProgress !optional;

--- a/Themes/Translucence/src/_variables.scss
+++ b/Themes/Translucence/src/_variables.scss
@@ -4,8 +4,11 @@
 	--app-margin: 24px;
 	--app-radius: 10px;
 
-	--sidebar-color: rgba(0,0,0,0.4);
-	--main-content-color: rgba(0,0,0,0.2);
+	--main-rgb: 0,0,0;
+	--main-content-opacity: 0.2;
+	--sidebar-opacity: 0.4;
+	--main-content-color: rgba(var(--main-rgb), var(--main-content-opacity));
+	--sidebar-color: rgba(var(--main-rgb), var(--sidebar-opacity));
 
 	--accent-hue: 156;
 	--accent-saturation: 77.5%;

--- a/Themes/Translucence/src/channels/_channels.scss
+++ b/Themes/Translucence/src/channels/_channels.scss
@@ -25,7 +25,7 @@
 
     %voiceChannelsButton {
         &:hover {
-            background-color: var(--background-modifier-selected);
+            background-color: var(--background-modifier-hover);
         }
     }
 }

--- a/Themes/Translucence/src/chat/_searchResults.scss
+++ b/Themes/Translucence/src/chat/_searchResults.scss
@@ -5,7 +5,7 @@
  */
 
 %searchResultsWrap {
-    background-color: var(--sidebar-color);
+    background-color: rgba( var(--main-rgb), calc( (var(--sidebar-opacity) - var(--main-content-opacity)) / (1 - var(--main-content-opacity)) ));
 }
 
 /* SEARCH RESULTS -> HEADER */

--- a/Themes/Translucence/src/general/_cards.scss
+++ b/Themes/Translucence/src/general/_cards.scss
@@ -17,6 +17,18 @@
 		border-style: solid !important;
 		border-width: 1px !important;
 		border-color: transparent !important;
+
+		%applicationPermissionsCardHeader {
+			background-color: unset;
+			border-bottom: 1px solid var(--card-color);
+		}
+
+		%applicationPermissionButtonGroup {
+			background-color: var(--card-color);
+			border-radius: var(--button-radius);
+			border: none;
+			overflow: hidden;
+		}
 	}
 }
 

--- a/Themes/Translucence/src/general/_cards.scss
+++ b/Themes/Translucence/src/general/_cards.scss
@@ -12,6 +12,14 @@
 	@include card-format(true);
 }
 
+%applicationPermissions {
+	%settingsCardPrimary {
+		border-style: solid !important;
+		border-width: 1px !important;
+		border-color: transparent !important;
+	}
+}
+
 %settingsLongCardButton {
 	background-color: var(--card-color) !important;
 

--- a/Themes/Translucence/src/general/_cards.scss
+++ b/Themes/Translucence/src/general/_cards.scss
@@ -12,26 +12,23 @@
 	@include card-format(true);
 }
 
-%settingsContentColumn {
-	%settingsCardPrimary {
-		border-style: solid !important;
-		border-width: 1px !important;
-		border-color: transparent !important;
+%settingsCardPrimary {
+	border-style: solid !important;
+	border-width: 1px !important;
+	border-color: transparent !important;
 
-		%applicationPermissionsCardHeader {
-			background-color: unset;
-			border-bottom: 1px solid var(--card-color);
-		}
+	%applicationPermissionsCardHeader {
+		background-color: unset;
+		border-bottom: 1px solid var(--card-color);
+	}
 
-		%applicationPermissionsButtonGroup {
-			background-color: var(--card-color);
-			border-radius: var(--button-radius);
-			border: none;
-			overflow: hidden;
-		}
+	%applicationPermissionsButtonGroup {
+		background-color: var(--card-color);
+		border-radius: var(--button-radius);
+		border: none;
+		overflow: hidden;
 	}
 }
-
 %settingsLongCardButton {
 	background-color: var(--card-color) !important;
 

--- a/Themes/Translucence/src/general/_cards.scss
+++ b/Themes/Translucence/src/general/_cards.scss
@@ -12,7 +12,7 @@
 	@include card-format(true);
 }
 
-%applicationPermissions {
+%settingsContentColumn {
 	%settingsCardPrimary {
 		border-style: solid !important;
 		border-width: 1px !important;
@@ -23,7 +23,7 @@
 			border-bottom: 1px solid var(--card-color);
 		}
 
-		%applicationPermissionButtonGroup {
+		%applicationPermissionsButtonGroup {
 			background-color: var(--card-color);
 			border-radius: var(--button-radius);
 			border: none;

--- a/Themes/Translucence/src/messages/_attachment.scss
+++ b/Themes/Translucence/src/messages/_attachment.scss
@@ -67,7 +67,7 @@
 
 /* ATTACHMENTS -> TEXT CONTAINER */
 
-%newMosaicStyle {
+
 
     %textContainer,
     %textContainerFooter {
@@ -78,13 +78,17 @@
     %textContainer {
         border-radius: var(--card-radius) var(--card-radius) 0 0;
         box-shadow: var(--card-header-shadow);
+
+        %codeHLJS {
+            background-color: transparent;
+        }
     }
 
 
     %textContainerFooter {
         border-radius: 0 0 var(--card-radius) var(--card-radius);
     }
-}
+
 
 
 %textContainerModal {

--- a/Themes/Translucence/src/messages/_attachment.scss
+++ b/Themes/Translucence/src/messages/_attachment.scss
@@ -71,6 +71,7 @@
 %textContainerFooter {
     background-color: var(--card-color);
     border: none;
+    border-radius: 0 0 var(--card-radius) var(--card-radius);
 }
 
 %textContainer {
@@ -82,12 +83,11 @@
     }
 }
 
-
-%textContainerFooter {
-    border-radius: 0 0 var(--card-radius) var(--card-radius);
+%attachmentNewMosaicStyle {
+    %textContainerFooter {
+        border-radius: 0 0 var(--card-radius) var(--card-radius);
+    }
 }
-
-
 
 %textContainerModal {
     background-color: var(--popout-color);

--- a/Themes/Translucence/src/messages/_attachment.scss
+++ b/Themes/Translucence/src/messages/_attachment.scss
@@ -43,7 +43,10 @@
     border: none;
 }
 
-
+%inviteSplash {
+    border-top-right-radius: var(--card-radius);
+	border-top-left-radius: var(--card-radius);
+}
 
 %voiceMessageContainer {
 	background-color: var(--card-color);

--- a/Themes/Translucence/src/messages/_attachment.scss
+++ b/Themes/Translucence/src/messages/_attachment.scss
@@ -67,28 +67,33 @@
 
 /* ATTACHMENTS -> TEXT CONTAINER */
 
-%textContainer,
-%textContainerFooter {
-    background-color: var(--card-color);
-    border: none;
-}
+%newMosaicStyle {
 
-%textContainer {
-    border-radius: var(--card-radius) var(--card-radius) 0 0;
-    box-shadow: var(--card-header-shadow);
+    %textContainer,
+    %textContainerFooter {
+        background-color: var(--card-color);
+        border: none;
+    }
 
-    %codeHLJS {
-        background-color: transparent;
+    %textContainer {
+        border-radius: var(--card-radius) var(--card-radius) 0 0;
+        box-shadow: var(--card-header-shadow);
+    }
+
+
+    %textContainerFooter {
+        border-radius: 0 0 var(--card-radius) var(--card-radius);
     }
 }
 
-%textContainerFooter {
-    border-radius: 0 0 var(--card-radius) var(--card-radius);
-}
 
 %textContainerModal {
     background-color: var(--popout-color);
     border-radius: var(--popout-radius) var(--popout-radius) 0 0;
     border: none;
     box-shadow: var(--card-header-shadow);
+
+    %codeHLJS {
+        background-color: transparent;
+    }
 }

--- a/Themes/Translucence/src/messages/_attachment.scss
+++ b/Themes/Translucence/src/messages/_attachment.scss
@@ -77,16 +77,16 @@
     border-radius: 0 0 var(--card-radius) var(--card-radius);
 }
 
-%textContainer {
-    border-radius: var(--card-radius) var(--card-radius) 0 0;
-    box-shadow: var(--card-header-shadow);
-
-    %codeHLJS {
-        background-color: transparent;
-    }
-}
-
 %attachmentNewMosaicStyle {
+    %textContainer {
+        border-radius: var(--card-radius) var(--card-radius) 0 0;
+        box-shadow: var(--card-header-shadow);
+
+        %codeHLJS {
+            background-color: transparent;
+        }
+    }
+
     %textContainerFooter {
         border-radius: 0 0 var(--card-radius) var(--card-radius);
     }

--- a/Themes/Translucence/src/messages/_attachment.scss
+++ b/Themes/Translucence/src/messages/_attachment.scss
@@ -67,27 +67,25 @@
 
 /* ATTACHMENTS -> TEXT CONTAINER */
 
+%textContainer,
+%textContainerFooter {
+    background-color: var(--card-color);
+    border: none;
+}
 
+%textContainer {
+    border-radius: var(--card-radius) var(--card-radius) 0 0;
+    box-shadow: var(--card-header-shadow);
 
-    %textContainer,
-    %textContainerFooter {
-        background-color: var(--card-color);
-        border: none;
+    %codeHLJS {
+        background-color: transparent;
     }
-
-    %textContainer {
-        border-radius: var(--card-radius) var(--card-radius) 0 0;
-        box-shadow: var(--card-header-shadow);
-
-        %codeHLJS {
-            background-color: transparent;
-        }
-    }
+}
 
 
-    %textContainerFooter {
-        border-radius: 0 0 var(--card-radius) var(--card-radius);
-    }
+%textContainerFooter {
+    border-radius: 0 0 var(--card-radius) var(--card-radius);
+}
 
 
 

--- a/Themes/Translucence/src/messages/_markup.scss
+++ b/Themes/Translucence/src/messages/_markup.scss
@@ -14,7 +14,7 @@
 	}
 
 	code {
-		background-color: var(--card-color);
+		background-color: var(--textarea-block-color);
 		border-radius: var(--card-radius);
 		border: none;
 	}

--- a/Themes/Translucence/src/popouts/_contextMenu.scss
+++ b/Themes/Translucence/src/popouts/_contextMenu.scss
@@ -23,4 +23,12 @@
             left: 8px;
         }
     }
+
+    %contextMenuQuickReaction {
+        background-color: var(--card-color);
+
+        &:hover {
+            background-color: var(--card-color-hover);
+        }
+    }
 }

--- a/Themes/Translucence/src/settings/server/_insights.scss
+++ b/Themes/Translucence/src/settings/server/_insights.scss
@@ -27,3 +27,12 @@
         @include card-format;
     }
 }
+
+%insightsDeveloperPortalCtaWrapper {
+    background-color: var(--card-color);
+}
+
+%insightsError {
+    background-color: var(--card-color);
+    border-radius: var(--card-radius);
+}

--- a/Themes/Translucence/src/settings/server/_roles.scss
+++ b/Themes/Translucence/src/settings/server/_roles.scss
@@ -27,7 +27,11 @@
 
     &:hover {
         %buttonCircle {
-            background-color: var(--main-content-color) !important;
+            background-color: var(--background-modifier-active) !important;
+
+            &:hover {
+                background-color: var(--background-modifier-hover) !important;
+            }
         }
     }
 }

--- a/Themes/Translucence/src/settings/server/_stickers.scss
+++ b/Themes/Translucence/src/settings/server/_stickers.scss
@@ -26,12 +26,28 @@
 
 %stickersUploadCard {
 	@include card-format(false, true);
+
+	%stickerCardButtons {
+		background-color: var(--card-color);
+	}
 }
 
 %stickersProgressBackground {
 	color: var(--card-color) !important;
 }
 
-%stickersTierInProgress {
-	background-color: var(--card-color) !important;
+%stickersProgressForground {
+	color: hsla(var(--accent-hsl), var(--accent-opacity));
+}
+
+%themeDark {
+	%stickersTierInProgress {
+		background-color: var(--card-color);
+	}
+
+	%stickersTierAccomplished,
+	%stickersTierCurrent,
+	%stickersTierFirst {
+		background: hsla(var(--accent-hsl), var(--accent-opacity));
+	}
 }

--- a/Themes/Translucence/src/settings/user/_voiceVideo.scss
+++ b/Themes/Translucence/src/settings/user/_voiceVideo.scss
@@ -1,0 +1,24 @@
+/*
+ *
+ *  USER SETTINGS VOICE & VIDEO
+ *
+ */
+
+ %cameraWrapper {
+    background: var(--card-color);
+    border-radius: var(--card-radius);
+    border-color: hsla(var(--accent-hsl), var(--accent-opacity));
+    border-width: 2px;
+ }
+
+ %videoBgOption {
+    %videoBgOptionRing {
+        border-radius: var(--card-radius);
+        border-color: hsla(var(--accent-hsl), var(--accent-opacity));
+    }
+
+    %videoBgOptionInner {
+        background: var(--card-color);
+        border-radius: var(--card-radius);
+    }
+ }

--- a/Themes/Translucence/src/userprofiles/_userprofiles.scss
+++ b/Themes/Translucence/src/userprofiles/_userprofiles.scss
@@ -1,0 +1,11 @@
+/*
+ *
+ *  USERPROFILES
+ *
+ */
+
+%avatarWrapper {
+    %avatarStatusRect {
+        filter: saturate(var(--saturation-factor));
+    }
+}


### PR DESCRIPTION
css compiled with
```
sass .\main.scss:.\css\source.css --no-source-map
```
hope I didnt overlook anything, tested with original translucence.theme.css

split ``--sidebar-color`` and ``--main-content-color`` in
```css
        --main-rgb: 0,0,0;
	--main-content-opacity: 0.2;
	--sidebar-opacity: 0.4;
	--sidebar-color: rgba(var(--main-rgb), var(--sidebar-opacity));
	--main-content-color: rgba(var(--main-rgb), var(--main-content-opacity));
``` 
to match searchbar opacity