### PR TITLE
adds border-radius support for super reactions

### DIFF
--- a/Themes/Translucence/src/_selectorPlaceholders.scss
+++ b/Themes/Translucence/src/_selectorPlaceholders.scss
@@ -3982,6 +3982,9 @@ pre {
 .reaction-3vwAF2, .reaction-102jx9 {
 	@extend %reaction !optional;
 }
+.burstGlow-3AZMzF {
+	@extend %reactionGlow !optional;
+}
 .reactionMe-1PwQAc, .reactionMe-2zhiyZ {
 	@extend %reactionMe !optional;
 }

--- a/Themes/Translucence/src/messages/_reaction.scss
+++ b/Themes/Translucence/src/messages/_reaction.scss
@@ -25,6 +25,10 @@
 			color: hsla(var(--accent-hsl),var(--accent-opacity));
 		}
 	}
+
+	%reactionGlow {
+		border-radius: var(--message-radius);
+	}
 }
 
 /* MESSAGE REACTIONS -> REVERT BUTTONS TO REACTION STYLE */


### PR DESCRIPTION
fixes gap that appears when using message-radius different from default on super reactions.
![image](https://github.com/CapnKitten/BetterDiscord/assets/116394977/43f018c9-2f04-4d92-8a0e-1938a7d672a1)