### PR TITLE
Fix unread channel spacing in the inbox popout

### DIFF
--- a/Themes/Material-Discord/css/source.css
+++ b/Themes/Material-Discord/css/source.css
@@ -13413,7 +13413,7 @@ body:active .recentMentionsPopout__95796:not(:active) {
   background-color: var(--menu-item-hover);
 }
 
-.channel__427f0 {
+.scroller__2692d > :first-child .channel__427f0 {
   margin-top: 16px;
 }
 

--- a/Themes/Material-Discord/src/_selectorPlaceholders.scss
+++ b/Themes/Material-Discord/src/_selectorPlaceholders.scss
@@ -8005,6 +8005,9 @@ pre {
 .tutorialIcon__2692d{
 	@extend %unreadTutorialIcon !optional;
 }
+.scroller__2692d {
+	@extend %unreadChannelList !optional;
+}
 .channel__427f0 {
 	@extend %unreadChannel !optional;
 }

--- a/Themes/Material-Discord/src/popouts/_messages.scss
+++ b/Themes/Material-Discord/src/popouts/_messages.scss
@@ -104,7 +104,7 @@ body:active {
 	}
 }
 
-%unreadChannel {
+%unreadChannelList > :first-child %unreadChannel {
 	margin-top: 16px;
 }
 


### PR DESCRIPTION
Hi, the spacing in the inbox now looks oddly large between rows after some new discord update.

It's a fairly quick fix, only applying the `margin-top: 16px;` to the first child of the scroller, as I did here.

Old look:
![image](https://github.com/user-attachments/assets/23c4ec1c-3911-4a02-b6b5-e712a739f646)
New look:
![image](https://github.com/user-attachments/assets/3d3b7bfd-66ee-48d4-8823-1de7414db4ba)

I am using the material you add-on, but that shouldn't change much.