### PR TITLE
FIX - Change the google font css path to a correct one

### DIFF
--- a/Themes/Material-Discord/css/source.css
+++ b/Themes/Material-Discord/css/source.css
@@ -1,5 +1,5 @@
-@import url("https://capnkitten.github.io/BetterDiscord/Themes/Material-Discord/files/fonts/google-sans-flex.css");
-@import url("https://capnkitten.github.io/BetterDiscord/Themes/Material-Discord/files/fonts/google-sans-code.css");
+@import url("https://capnkitten.github.io/BetterDiscord/Themes/Material-Discord/css/fonts/google-sans-flex.css");
+@import url("https://capnkitten.github.io/BetterDiscord/Themes/Material-Discord/css/fonts/google-sans-code.css");
 @import url("https://capnkitten.github.io/BetterDiscord/Themes/Material-Discord/css/icons.css");
 :root {
   --app-font: "Google Sans Flex";


### PR DESCRIPTION
- The theme is giving an error because it is referencing the font css file at the wrong place; It is in `../css/fonts/...`, not in `../files/fonts/..`.